### PR TITLE
Modification de l'utilisation du SignInManager pour empêcher cookie

### DIFF
--- a/WebTemplate.API/Config/DataBaseConfig.cs
+++ b/WebTemplate.API/Config/DataBaseConfig.cs
@@ -1,11 +1,10 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using WebTemplate.Domain.Users;
 using WebTemplate.Infrastructure.EntityFrameworkCore;
-using WebTemplate.Infrastructure.Identity.Services;
-using Microsoft.AspNetCore.Identity;
 using WebTemplate.Infrastructure.Identity.Models;
+using WebTemplate.Infrastructure.Identity.Services;
 
 namespace WebTemplate.API.Config
 {
@@ -19,7 +18,8 @@ namespace WebTemplate.API.Config
                 options.UseSqlServer(configuration.GetConnectionString("Database"))
             );
 
-            services.AddIdentity<ApplicationUser, IdentityRole>()
+            services.AddIdentityCore<ApplicationUser>()
+                    .AddRoles<IdentityRole>()
                     .AddDefaultTokenProviders()
                     .AddUserManager<UserManager<ApplicationUser>>()
                     .AddSignInManager<SignInManager<ApplicationUser>>()

--- a/WebTemplate.API/Controllers/HomeController.cs
+++ b/WebTemplate.API/Controllers/HomeController.cs
@@ -22,7 +22,6 @@ namespace WebTemplate.API.Controllers
     /// </summary>
 
     [Route("api/[controller]")]
-    [ApiConventionType(typeof(WebTemplateApiConventions))]
     [ApiController]
     public class HomeController : ControllerBase
     {
@@ -35,6 +34,7 @@ namespace WebTemplate.API.Controllers
             _voitureRepository = voitureRepository;
         }
 
+        [Authorize()]
         [HttpGet]
         public async Task<ActionResult<UserDto>> GetUser(string name)
         {

--- a/WebTemplate.API/Models/Authenticate.cs
+++ b/WebTemplate.API/Models/Authenticate.cs
@@ -88,9 +88,7 @@ namespace WebTemplate.API.Models
             {
                 CommandResponse response = new CommandResponse();
 
-                string ipAddress = _httpContext!.Connection.RemoteIpAddress!.MapToIPv4().ToString();
-
-                TokenResponse tokenResponse = await _tokenService.Authenticate(command, ipAddress);
+                TokenResponse tokenResponse = await _tokenService.Authenticate(command);
                 if (tokenResponse == null)
                 {
                     throw new Exception("Invalid Username and/or Password. Please try again");

--- a/WebTemplate.API/Program.cs
+++ b/WebTemplate.API/Program.cs
@@ -28,7 +28,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.SetupSwagger(builder.Configuration);
 
 builder.Services.SetAuthorization();
-
+builder.Services.AddHttpContextAccessor();
 builder.Services.SetupDatabase(builder.Configuration);
 
 builder.Host.UseServiceProviderFactory(new AutofacServiceProviderFactory())

--- a/WebTemplate.Infrastructure/Identity/Services/ITokenService.cs
+++ b/WebTemplate.Infrastructure/Identity/Services/ITokenService.cs
@@ -10,6 +10,6 @@ namespace WebTemplate.Infrastructure.Identity.Services
 {
     public interface ITokenService
     {
-        Task<TokenResponse> Authenticate(TokenRequest request, string ipAddress);
+        Task<TokenResponse> Authenticate(TokenRequest request);
     }
 }

--- a/WebTemplate.Infrastructure/Identity/Services/TokenService.cs
+++ b/WebTemplate.Infrastructure/Identity/Services/TokenService.cs
@@ -36,7 +36,7 @@ namespace WebTemplate.Infrastructure.Identity.Services
         }
 
         /// <inheritdoc cref="ITokenService.Authenticate(TokenRequest, string)"/>
-        public async Task<TokenResponse> Authenticate(TokenRequest request, string ipAddress)
+        public async Task<TokenResponse> Authenticate(TokenRequest request)
         {
             if (await IsValidUser(request.Username!, request.Password!))
             {
@@ -52,7 +52,6 @@ namespace WebTemplate.Infrastructure.Identity.Services
                     return new TokenResponse(user,
                                              role,
                                              jwtToken
-                                             //""//refreshToken.Token
                                              );
                 }
             }
@@ -70,7 +69,10 @@ namespace WebTemplate.Infrastructure.Identity.Services
                 return false;
             }
 
-            SignInResult signInResult = await _signInManager.PasswordSignInAsync(user, password, true, false);
+            //If you need cookies, please use PasswordSignInAsync(username, password, true,false);  
+            //SignInResult signInResult = await _signInManager.PasswordSignInAsync(user, password, true, false);
+
+            SignInResult signInResult = await _signInManager.CheckPasswordSignInAsync(user, password,false);
 
             return signInResult.Succeeded;
         }


### PR DESCRIPTION
SignInManager renvoyé un cookie par défaut.
Remplacement de :

`SignInResult signInResult = await _signInManager.PasswordSignInAsync(user, password, true, false); `
Par:
`SignInResult signInResult = await _signInManager.CheckPasswordSignInAsync(user, password,false);`